### PR TITLE
Fix new Atom versions bugs

### DIFF
--- a/styles/panels.less
+++ b/styles/panels.less
@@ -1,32 +1,52 @@
 @import "ui-mixins";
 @import "ui-variables";
 @import "buttons";
+
 .panel {
     &.bordered {
         border: 5px solid @base-border-color;
         border-radius: @component-border-radius;
     }
 }
+
 .tool-panel {
     color: #333;
     position: relative;
     background-image: url("http://subtlepatterns2015.subtlepatterns.netdna-cdn.com/patterns/gplaypattern.png");
-    a {
+
+	a {
         color: #333;
     }
-    .status-bar {
+
+	.find-and-replace .options-label .options {
+		color: @text-color-subtle;
+	}
+
+    status-bar {
         linter-bottom-tab {
             color: #fafafa;
         }
+
+		a {
+			.text-inverted(normal);
+
+			&:hover {
+				.text-inverted(highlight);
+			}
+		}
+
         .cursor-position {
-            a {
+            a,
+			a:hover {
                 color: #1abc9c;
             }
         }
     }
+
     & atom-panel.bottom {
         font-size: @font-size;
     }
+
     section {
         .input-block-item {
             .btn-group {
@@ -39,17 +59,16 @@
         }
     }
 }
+
 .inset-panel {
     position: relative;
     background-color: @inset-panel-background-color;
 }
-.is-blurred {
-    .inset-panel,
-    .tool-panel {}
-}
+
 .panel-heading {
     .text(normal);
     background-color: @panel-heading-background-color;
+
     .btn {
         padding-left: 8px;
         padding-right: 8px;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -1,5 +1,14 @@
 @import "ui-variables";
+
 .tree-view {
-    background-color: @tree-view-background-color;
+	background-color: @tree-view-background-color;
     background-image: url("http://subtlepatterns2015.subtlepatterns.netdna-cdn.com/patterns/gplaypattern.png");
+
+	.tree-view-root {
+		background-color: transparent !important;
+	}
+
+	.file.entry {
+		color: @tree-view-font-color;
+	}
 }

--- a/styles/ui-mixins.less
+++ b/styles/ui-mixins.less
@@ -8,3 +8,6 @@
 .text(info) { color: @text-color-info; }
 .text(warning) { color: @text-color-warning; }
 .text(error) { color: @text-color-error; }
+
+.text-inverted(normal) { color: @text-color-inverted; }
+.text-inverted(highlight) { color: @text-color-inverted-highlight; }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -5,16 +5,19 @@
 @text-color-highlight: #fff;
 @text-color-selected: @text-color;
 
-@text-color-info: #9A9A9A;
-@text-color-success: #17c984;
-@text-color-warning: #ff8b2d;
-@text-color-error: #c62b2b;
+@text-color-info: 		#9A9A9A;
+@text-color-success: 	#17c984;
+@text-color-warning: 	#ff8b2d;
+@text-color-error: 		#c62b2b;
 
 @text-color-ignored:  @text-color-subtle;
 @text-color-renamed:  @text-color-info;
 @text-color-added:    @text-color-success;
 @text-color-modified: @text-color-warning;
 @text-color-removed:  @text-color-error;
+
+@text-color-inverted:			#333;
+@text-color-inverted-highlight: #555;
 
 // BACKGROUND COLORS
 
@@ -42,16 +45,16 @@
 
 @tool-panel-background-color: #34495e;
 @tool-panel-border-color:     #2c3e50;
-@inset-panel-background-color: #bdc3c7;
-@inset-panel-border-color:     @base-border-color;
-@panel-heading-background-color: #7f8c8d;
-@panel-heading-border-color:     @base-border-color;
-@overlay-background-color: #333;
-@overlay-border-color:     @base-border-color;
+@inset-panel-background-color: 	#bdc3c7;
+@inset-panel-border-color:     	@base-border-color;
+@panel-heading-background-color: 	#7f8c8d;
+@panel-heading-border-color:     	@base-border-color;
+@overlay-background-color: 	#333;
+@overlay-border-color:     	@base-border-color;
 
 @button-background-color:          #2c3e50;
 @button-background-color-hover:    #2f4255;
-@button-background-color-selected: #2f4255;
+@button-background-color-selected: #1abc9c;
 @button-border-color:              #2c3e50;
 
 @tab-bar-background-color:    #1abc9c;
@@ -61,7 +64,8 @@
 @tab-text-color:              @text-color;
 @tab-text-color-active:       @text-color;
 
-@tree-view-background-color:  #2c3e50;
+@tree-view-background-color:  #eee;
+@tree-view-font-color:		  #444;
 @tree-view-border-color:      @base-border-color;
 
 @scrollbar-background-color: #1abc9c;


### PR DESCRIPTION
Hello Agnostics, I fixed some bugs I found with your UI theme with recent Atom versions. 

Here's a quick overview of what I fixed:
- The tree view background image didn't show properly and was always dark blue.
- The default tree view font color was white.
- The links in the status bar turned to bright white on `:hover`. 
- There was almost no change in style when a button was selected.
- The active options in the Search panel (Ctrl+F) were almost white on white background.

Here's a screenshot of the updated theme:
https://i.imgur.com/EE2Kx8T.png